### PR TITLE
Changed addOption and optionNames const char * to avoid memory duplication

### DIFF
--- a/src/OmWebPages.cpp
+++ b/src/OmWebPages.cpp
@@ -290,10 +290,10 @@ class PageSelect : public PageItem
 {
 public:
     OmWebActionProc proc = 0;
-    std::vector<String> optionNames;
+    std::vector<const char*> optionNames;
     std::vector<int> optionNumbers;
 
-    void addOption(String optionName, int optionNumber)
+    void addOption(const char *optionName, int optionNumber)
     {
         this->optionNames.push_back(optionName);
         this->optionNumbers.push_back(optionNumber);
@@ -325,7 +325,7 @@ public:
                 w.addAttribute("selected", "selected");
                 foundSelectedOption = true;
             }
-            w.addContent(this->optionNames[ix].c_str());
+            w.addContent(this->optionNames[ix]);
             w.endElement();
         }
 


### PR DESCRIPTION

This does mean the caller should make sure the strings do not go out of
scope (defining them globally or adding a static const char*, or using
malloc/ps_malloc, which for lots of strings, is better on ESP32 to use
more plentiful memory that static arrays cannot use.

Test
Before:
Heap/32-bit Memory Available     : 63968 bytes total, 42548 bytes largest free block
8-bit/malloc/DMA Memory Available: 21420 bytes total, 16744 bytes largest free block

After:
Heap/32-bit Memory Available     : 76804 bytes total, 42548 bytes largest free block
8-bit/malloc/DMA Memory Available: 34256 bytes total, 32184 bytes largest free block