### PR TITLE
Memory free on ESP32 was wrong with PSRAM.

### DIFF
--- a/src/OmWebPages.cpp
+++ b/src/OmWebPages.cpp
@@ -964,8 +964,18 @@ void OmWebPages::renderInfo(OmXmlWriter &w)
     w.addContentF("systemSdk:   %s/%d\n", system_get_sdk_version(), system_get_boot_version());
 #endif
 #ifdef ARDUINO_ARCH_ESP32
-    w.addContentF("freeBytes:   %d\n", esp_get_free_heap_size());
-    w.addContentF("chipId:      '32 @%d\n", F_CPU / 1000000);
+    // ESP32 has 3 kinds of memory: 32bit (used for heap), 8bit (also used for DMA), and PSRAM
+    // For the first 2, we show the total amount available, and the largest block available
+    w.addContentF("32-bit Mem:  %d\n", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+    w.addContentF("32-bit Block:%d\n", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
+    w.addContentF("8b/DMA Mem:  %d\n", heap_caps_get_free_size(MALLOC_CAP_DMA));
+    w.addContentF("8b/DMA Block:%d\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+#ifdef BOARD_HAS_PSRAM
+    // https://thingpulse.com/esp32-how-to-use-psram/
+    w.addContentF("PSRAM used:  %d\n", ESP.getPsramSize() - ESP.getFreePsram());
+    w.addContentF("PSRAM free:  %d\n", ESP.getFreePsram());
+#endif
+    w.addContentF("chipId:      ESP32 @%d\n", F_CPU / 1000000);
 #endif
 #ifdef NOT_ARDUINO
     w.addContentF("what:        Not Arduino\n");


### PR DESCRIPTION
It was also very incomplete. ESP32 has 32bit and 8bit memory that
aren't usable for the same things (some things require 8bit memory
others will work with 32bit memory too).

This is what it looks like now:
requests:    1
maxHtml:     0
uptime:      1m4s
32-bit Mem:  95544
32-bit Block:51288
8b/DMA Mem:  52996
8b/DMA Block:51288
PSRAM used:  79148
PSRAM free:  4113720
chipId:      ESP32 @240
clientIp:    192.168.205.4:52842
serverIp:    192.168.205.178:80
wifiNetwork: magicnet-guest
built:       Dec 17 2020 18:27:17

Before the patch, it showed me that I had 4MB of memory free,
which was pretty useless :)